### PR TITLE
SRST2 Benchmark

### DIFF
--- a/ARG-Sniper-pipeline.nf
+++ b/ARG-Sniper-pipeline.nf
@@ -9,6 +9,7 @@ nextflow.enable.dsl=2
 include { groot_align } from './modules/groot'
 include { ariba_run } from './modules/ariba'
 include { ariba_summary } from './modules/ariba'
+include { srst2 } from './modules/srst2'
 
 // Function which prints help message text
 def helpMessage() {
@@ -33,6 +34,7 @@ Required Arguments:
 params.all = true
 params.groot = false
 params.ariba = false
+params.srst2 = false
 params.help = false
 
 // Main workflow
@@ -92,4 +94,11 @@ workflow {
     //     path(ariba_report)
     }
 
+    if(params.all || params.srst2){
+        srst2(
+            fastq_ch
+        )
+    // output:
+    //     path(srst2_report_<sample_name>.tsv)
+    }
 }

--- a/modules/srst2.nf
+++ b/modules/srst2.nf
@@ -1,0 +1,23 @@
+#!/usr/bin/env nextflow
+
+// Using DSL-2
+nextflow.enable.dsl=2
+
+// Align a genome with SRST2
+process srst2 {
+    maxRetries 5
+    container "${params.container__srst2}"
+    publishDir "${params.results_dir}/srst2", mode: 'copy'
+
+
+    input:
+    tuple val(sample_name), path(R1_fastq), path(R2_fastq)
+
+    output:
+    path "srst2_report_*.txt"
+
+    shell:
+    '''
+    micromamba run -p /opt/conda/envs/srst2 srst2 --forward '_R1' --reverse '_R2' --input_pe !{R1_fastq} !{R2_fastq} --output srst2_report_!{sample_name} --log --gene_db !{params.srst2_ref_database} --threads !{params.NCPUS}
+    '''
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -8,8 +8,10 @@ defined below.
 params {
     indexed_groot_database = '/qib/research-groups/CoreBioInfo/projects/arg-snipper/databases/panarg_2_groot/index' 
     ariba_ref_database = '/qib/scratch/users/zaf24vof/prepare'
+    srst2_ref_database = '/qib/research-groups/CoreBioInfo/projects/arg-snipper/databases/panarg_2_srst2/sequence.fa'
     work_dir = '~/Documents'
     fastq_folder = '/qib/research-groups/CoreBioInfo/projects/arg-snipper/raw-reads/simulated_reads/resistance_profile/'
+    container__srst2 = '/qib/research-groups/CoreBioInfo/projects/arg-snipper/singulariy-images/srst2-2.0.0.img'
     container__groot = '/qib/research-groups/CoreBioInfo/projects/arg-snipper/singulariy-images/groot-1.1.2--heaae5f8_5.img'
     container__ariba = '/qib/research-groups/CoreBioInfo/projects/arg-snipper/singulariy-images/ariba_2.14.6--py39heaaa4ec_6.img'
     NCPUS = 16


### PR DESCRIPTION
- created a new singularity image as the bioconda image does not work correctly. Available at /qib/research-groups/CoreBioInfo/projects/arg-snipper/singulariy-images/srst2-2.0.0.img 
- added an SRST2 module
- Had to include a MaxRetry = 3 directive to SRST2 as it can have erratic behaviour if no reads are aligned (which can happen as reads counts are low and alignment is not entirely deterministic).